### PR TITLE
fix(getAdminAddFields): fix endless-loop

### DIFF
--- a/components/modules/ispapi/ispapi.php
+++ b/components/modules/ispapi/ispapi.php
@@ -1114,7 +1114,9 @@ class Ispapi extends RegistrarModule
                             $('#transfer_key_id').closest('li').hide();
                     });
                     // Refresh the page when typed in domain name in in order to display additional fields
-                    $('input[name=\"domain\"]').change(function() {
+                    $('input[name=\"domain\"]').change(function(event) {
+                        // do not refresh if domain has not actually changed (some change events are triggered automatically)
+                        if (event.target.value.toLowerCase() === '" . ($vars->domain ?? '') . "'.toLowerCase()) return;
                         $('input[type=radio]').attr('checked',false);
                         var form = $(this).closest('form');
                         $(form).append('<input type=\"hidden\" name=\"refresh_fields\" value=\"true\">');


### PR DESCRIPTION
Fixes endless-loop with page-refreshes on admin -> add service

Current versions of blesta are triggering the .change() event on all fields at page load in some circumstances (once a pricing is selected).
Because the ispapi plugin is listening for change events in the domain field and then refreshing the page, this resulted in an endless-loop (page always refreshing)
This fix will prevent a page refresh if the domain field value has not actually changed.